### PR TITLE
Make `PluginType` stateless

### DIFF
--- a/src/Elcodi/Bundle/PluginBundle/Resources/config/formTypes.yml
+++ b/src/Elcodi/Bundle/PluginBundle/Resources/config/formTypes.yml
@@ -5,3 +5,5 @@ services:
     #
     elcodi.form_type.plugin:
         class: Elcodi\Component\Plugin\Form\Type\PluginType
+        tags:
+            - { name: form.type, alias: elcodi_form_type_plugin }

--- a/src/Elcodi/Component/Plugin/Form/Type/PluginType.php
+++ b/src/Elcodi/Component/Plugin/Form/Type/PluginType.php
@@ -19,6 +19,7 @@ namespace Elcodi\Component\Plugin\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 use Elcodi\Component\Plugin\Entity\Plugin;
 
@@ -28,20 +29,13 @@ use Elcodi\Component\Plugin\Entity\Plugin;
 class PluginType extends AbstractType
 {
     /**
-     * @var Plugin
-     *
-     * Plugin
+     * @param OptionsResolver $resolver
      */
-    private $plugin;
-
-    /**
-     * Construct
-     *
-     * @param Plugin $plugin Plugin
-     */
-    public function __construct(Plugin $plugin)
+    public function configureOptions(OptionsResolver $resolver)
     {
-        $this->plugin = $plugin;
+        $resolver
+            ->setRequired('plugin')
+            ->setAllowedTypes('plugin', 'Elcodi\Component\Plugin\Entity\Plugin');
     }
 
     /**
@@ -52,11 +46,11 @@ class PluginType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $fields = $this
-            ->plugin
-            ->getFields();
-
-        foreach ($fields as $fieldName => $field) {
+        /**
+         * @var Plugin $plugin
+         */
+        $plugin = $options['plugin'];
+        foreach ($plugin->getFields() as $fieldName => $field) {
             $builder
                 ->remove($fieldName)
                 ->add($fieldName, $field['type'], array_merge([

--- a/src/Elcodi/Component/Plugin/Form/TypeExtension/AbstractPluginTypeExtension.php
+++ b/src/Elcodi/Component/Plugin/Form/TypeExtension/AbstractPluginTypeExtension.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the Elcodi package.
+ *
+ * Copyright (c) 2014-2015 Elcodi.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ * @author Aldo Chiecchia <zimage@tiscali.it>
+ * @author Elcodi Team <tech@elcodi.com>
+ */
+
+namespace Elcodi\Component\Plugin\Form\TypeExtension;
+
+use Elcodi\Component\Plugin\Entity\Plugin;
+
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\FormBuilderInterface;
+
+/**
+ * Class AbstractPluginTypeExtension
+ *
+ * @author Berny Cantos <be@rny.cc>
+ */
+abstract class AbstractPluginTypeExtension extends AbstractTypeExtension
+{
+    /**
+     * @var Plugin
+     */
+    protected $plugin;
+
+    /**
+     * @param Plugin $plugin
+     */
+    public function __construct(Plugin $plugin)
+    {
+        $this->plugin = $plugin;
+    }
+
+    /**
+     * Build form function
+     *
+     * @param FormBuilderInterface $builder the formBuilder
+     * @param array                $options the options for this form
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        if ($options['plugin'] !== $this->plugin) {
+            return;
+        }
+
+        $this->buildPluginForm($builder, $options);
+    }
+
+    /**
+     * Returns the name of the type being extended.
+     *
+     * @return string The name of the type being extended
+     */
+    public function getExtendedType()
+    {
+        return 'elcodi_form_type_plugin';
+    }
+
+    /**
+     * Build form function
+     *
+     * @param FormBuilderInterface $builder the formBuilder
+     * @param array                $options the options for this form
+     */
+    abstract protected function buildPluginForm(FormBuilderInterface $builder, array $options);
+}


### PR DESCRIPTION
Clones https://github.com/elcodi/elcodi/pull/858

This helps extend `PluginType` with `PluginTypeExtension` classes, so we can customize plugin configuration even more.
