### PR TITLE
Fix stock

### DIFF
--- a/src/Elcodi/Bundle/CartBundle/Resources/config/eventListeners.yml
+++ b/src/Elcodi/Bundle/CartBundle/Resources/config/eventListeners.yml
@@ -11,7 +11,7 @@ services:
             - @elcodi.manager.cart
             - @elcodi.wrapper.currency
             - @elcodi.converter.currency
-            - ?@elcodi.store_uses_stock
+            - @?elcodi.store_uses_stock
         tags:
             - { name: kernel.event_listener, event: cart.preload, method: checkCartIntegrity, priority: 0 }
             - { name: kernel.event_listener, event: cart.onload, method: loadCartPrices, priority: 16 }


### PR DESCRIPTION
The actual syntax for optional dependencies is `@?` instead of `?@`.
