### PR TITLE
Avoid saving translation if form is invalid

### DIFF
--- a/src/Elcodi/Component/EntityTranslator/EventListener/EntityTranslatorFormEventListener.php
+++ b/src/Elcodi/Component/EntityTranslator/EventListener/EntityTranslatorFormEventListener.php
@@ -207,6 +207,10 @@ class EntityTranslatorFormEventListener implements EventSubscriberInterface
     {
         $entity = $event->getData();
         $form = $event->getForm();
+        if (!$form->isValid()) {
+            return;
+        }
+
         $formHash = $this->getFormHash($form);
         $entityConfiguration = $this->getTranslatableEntityConfiguration($entity);
 


### PR DESCRIPTION
When invalid data is entered in a form with `EntityTranslatorFormEventListener`, translations should not be saved. But they are.
This can lead to Doctrine exceptions about the entity being not saved (id is `null`) or other types of unexpected behaviour.
